### PR TITLE
Add mariadb versions to the supported version list.

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -11,7 +11,7 @@ import (
 )
 
 var supportedReleases = []string{
-	"8", "5.7",
+	"8", "5.7", "10.",
 }
 
 type dbResourceID struct {


### PR DESCRIPTION
This change allows the connector to run against a modern version of MariaDB. It runs in "5.7" mode of MySQL as the changes to roles in MySQL 8 don't appear to exist in MariaDB


MariaDB versions jumped from 5.x to 10.x in 2019. It does appear that MariaDB is working on releasing 11.0 soon.

I created https://github.com/ConductorOne/baton-mysql/issues/7 to track better support for MariaDB and others.