### PR TITLE
fix: mark connection-string as isSecret in config_schema

### DIFF
--- a/cmd/baton-mysql/config.go
+++ b/cmd/baton-mysql/config.go
@@ -10,6 +10,7 @@ var (
 		"connection-string",
 		field.WithDescription("The connection string for connecting to MySQL ($BATON_CONNECTION_STRING)"),
 		field.WithRequired(true),
+		field.WithIsSecret(true),
 	)
 	SkipDatabases = field.StringSliceField(
 		"skip-database",


### PR DESCRIPTION
Marks the MySQL `connection-string` config field as a secret.

## Why

`connection-string` (`user:password@tcp(host:port)/db`) embeds the database
password but was not flagged secret, so it was stored and surfaced as plain
config. This adds `field.WithIsSecret(true)` to the field definition in
`cmd/baton-mysql/config.go`.

baton-mysql defines its config in Go and ships no committed
`config_schema.json` at the repo root; `field.WithIsSecret(true)` is the
source of truth that the generated schema is built from, so this single change
is the equivalent of the schema fix.

> BREAKING: adding `isSecret: true` to these fields changes how existing
> configurations are stored. Customers with existing connector configurations
> will need to re-enter credentials after this change is deployed.

Review only — do not merge.
